### PR TITLE
Use 4.0.0-pre.2 version of crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,15 +291,16 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7383e242d3e07bf0951e8589d6eebd7f18bb1c1fc5fbec3fad796041a6aebd1"
+checksum = "ab7fc853396919d12055cc4051c303758a75ebca74223f5c9e0907a549452cc3"
 dependencies = [
  "base64",
  "borsh",
  "bs58",
  "near-primitives-core",
  "near-sdk-macros",
+ "near-sys",
  "near-vm-logic",
  "serde",
  "serde_json",
@@ -307,10 +308,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284a78d9eb8eda58330462fa0023a6d7014c941df1f0387095e7dfd1dc0f2bce"
+checksum = "44fcbacb1d2fedcb2e4aa05094d31ccbfa831c868ca1242d1345b3e45c6b8a6c"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -319,16 +320,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
+name = "near-sys"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2037337438f97d1ce5f7c896cf229dc56dacd5c01142d1ef95a7d778cde6ce7d"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "f6a7aa3f46fac44416d8a93d14f30a562c4d730a1c6bf14bffafab5f475c244a"
 
 [[package]]
 name = "near-vm-errors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "3.1.0"
+near-sdk = "4.0.0-pre.2"
 
 [profile.release]
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::near_bindgen;
 
-near_sdk::setup_alloc!();
-
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
 pub struct Contract {
@@ -18,20 +16,19 @@ impl Contract {
  * the rest of this file sets up unit tests
  * to run these, the command will be:
  * cargo test --package rust-template -- --nocapture
- * Note: 'rust-template' comes from cargo.toml's 'name' key
+ * Note: 'rust-template' comes from Cargo.toml's 'name' key
  */
 
 // use the attribute below for unit tests
 #[cfg(test)]
 mod tests {
     use super::*;
-    use near_sdk::{MockedBlockchain, testing_env};
-    use near_sdk::test_utils::VMContextBuilder;
-    use near_sdk::json_types::ValidAccountId;
+    use near_sdk::test_utils::{get_logs, VMContextBuilder};
+    use near_sdk::{testing_env, AccountId};
 
     // part of writing unit tests is setting up a mock context
     // provide a `predecessor` here, it'll modify the default context
-    fn get_context(predecessor: ValidAccountId) -> VMContextBuilder {
+    fn get_context(predecessor: AccountId) -> VMContextBuilder {
         let mut builder = VMContextBuilder::new();
         builder.predecessor_account_id(predecessor);
         builder


### PR DESCRIPTION
I'm still not seeing this project linked anywhere, so think it's safe to use the prerelease which is stable according to Austin. This will allow us to write the Zero to Hero tutorial for the crossword puzzle in a way that's more sensible. In particular, I think using the new `get_logs` functionality in unit tests will be great to demonstrate.